### PR TITLE
Added Tests That Allow Default Pandas TSV Export

### DIFF
--- a/hw1/submission_template/test/test_dataset.py
+++ b/hw1/submission_template/test/test_dataset.py
@@ -19,15 +19,25 @@ class DatasetTest(unittest.TestCase):
         print("Check header")
         with open(self.dataset_file_path, 'r') as f:
             header = f.readline()
-            self.assertEqual(header.startswith("tweet_id"), True)
+            startFlag = False
+            if header.startswith("tweet_id") or header.startswith("\t"):
+                startFlag = True
+            self.assertEqual(startFlag, True)
         f.close()
         df = pd.read_csv(self.dataset_file_path, sep='\t')
         cols = list(df.columns)
-        self.assertEqual(len(cols), 4)
-        self.assertEqual(cols[0], 'tweet_id')
-        self.assertEqual(cols[1], 'publish_date')
-        self.assertEqual(cols[2], 'content')
-        self.assertEqual(cols[3], 'trump_mention')
+        self.assertTrue(len(cols) in [4, 5])
+        if len(cols) == 4:
+            self.assertEqual(cols[0], 'tweet_id')
+            self.assertEqual(cols[1], 'publish_date')
+            self.assertEqual(cols[2], 'content')
+            self.assertEqual(cols[3], 'trump_mention')
+        else:
+            self.assertEqual(cols[0], 'Unnamed: 0')
+            self.assertEqual(cols[1], 'tweet_id')
+            self.assertEqual(cols[2], 'publish_date')
+            self.assertEqual(cols[3], 'content')
+            self.assertEqual(cols[4], 'trump_mention')
         print("✅")
         
         print("Check file contents")

--- a/hw1/submission_template/test/test_results.py
+++ b/hw1/submission_template/test/test_results.py
@@ -17,13 +17,20 @@ class ResultsTest(unittest.TestCase):
         print("Check header")
         with open(self.dataset_file_path, 'r') as f:
             header = f.readline()
-            self.assertEqual(header.startswith("result"), True)
+            if header.startswith("result") or header.startswith("\t"):
+                startFlag = True
+            self.assertEqual(startFlag, True)
         f.close()
         df = pd.read_csv(self.dataset_file_path, sep='\t')
         cols = list(df.columns)
-        self.assertEqual(len(cols), 2)
-        self.assertEqual(cols[0], 'result')
-        self.assertEqual(cols[1], 'value')
+        self.assertTrue(len(cols) in [2, 3])
+        if len(cols) == 2:
+            self.assertEqual(cols[0], 'result')
+            self.assertEqual(cols[1], 'value')
+        else:
+            self.assertEqual(cols[0], 'Unnamed: 0')
+            self.assertEqual(cols[1], 'result')
+            self.assertEqual(cols[2], 'value')
         print("✅")
         
         print("Check file contents")


### PR DESCRIPTION
The pandas tsv exports adds a `'\t` at the start of the header and fill that space up with line numbers. This fails in the current tests as the header is expected to start with the first column. Furthermore, it also fails due to the length expectation of the column array. I've added a quick fix that would allow both pandas exported .tsv files and manually fixed ones. Feel free to edit the code if you think there's a better fix or reject the request if this is intended behavior. 

Ex: 
<img width="556" alt="image" src="https://user-images.githubusercontent.com/47402993/132877583-90d2910c-87de-42e8-9dff-38c553395863.png">

This is how pandas exports automatically.

<img width="466" alt="image" src="https://user-images.githubusercontent.com/47402993/132877669-71c595d0-524a-4aac-a664-9877c0425e74.png">

This is after a manual fix to pass the test suite. Same is applicable for the `results.tsv` tests. 

I've asked about this in the office hours and was told its alright to open a PR, again, feel free to reject it if its intended behavior. 